### PR TITLE
商品一覧表示のリンク指定編集

### DIFF
--- a/app/views/products/_pickupbrand.html.haml
+++ b/app/views/products/_pickupbrand.html.haml
@@ -9,7 +9,7 @@
     .productLists
       - @products.each do |product|
         .productList
-          = link_to "#" do
+          = link_to product_path(product) do
             %figure.productList--img
               =image_tag (product.images[0].src.url)
             .productList--body


### PR DESCRIPTION
# what
商品一覧表示のリンク編集
# why
商品一覧表示のリンク先の指定が必須のため
