### PR TITLE
product-detail fourth commit

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -15,7 +15,7 @@
                 %li.thimbnail-image
                   = image_tag image.src.url
           .itemBox__price
-            %span 
+            %span
               = @product.price
             .itemBox__price-detail
               %span


### PR DESCRIPTION
#what 
発送元の地域にちゃんと都道府県名が表示されるようにする

#why
idを表す文字列になってしまっていたため