### PR TITLE
product-detail sixth-commit

### DIFF
--- a/app/assets/javascripts/imagesSwitching.js
+++ b/app/assets/javascripts/imagesSwitching.js
@@ -1,0 +1,9 @@
+$(function () {
+  $(".thumbnail-image").first().addClass("active"); // 1枚目の小画像をアクティブに変更
+  $('.image-sub-photo').click(function () { // 小画像がクリックされたらイベント発火
+    image_url = $(this).attr("src"); // クリックされた画像のPATHを取得
+    $(".image-main-photo").attr("src", image_url).hide().fadeIn(); // メイン画像をクリックされた画像に変更
+    $(".thumbnail-image.active").removeClass("active"); // 1枚目の小画像のアクティブを無効化
+    $(this).parent().addClass("active"); // クリックされた小画像をアクティブに変更
+  });
+});

--- a/app/assets/stylesheets/modules/_products.scss
+++ b/app/assets/stylesheets/modules/_products.scss
@@ -589,11 +589,32 @@
                 width: 560px;
                 align-items: center;
                 margin: 0 auto;
+                position: relative;
                 img {
                   object-fit: cover;
                   height: 346px;
                   width: 100%;
                   vertical-align: bottom;
+                }
+                .sold-band {
+                  width: 0;
+                  height: 0;
+                  border-top: 60px solid #ea352d;
+                  border-right: 60px solid transparent;
+                  border-bottom: 60px solid transparent;
+                  border-left: 60px solid #ea352d;
+                  z-index: 100;
+                  position:absolute;
+                  top:0;
+                  left:0;
+                  .sold-band-inner {
+                    transform: rotate(-45deg);
+                    font-size: 25px;
+                    margin: -35px 0px 0px -55px;
+                    color: #fff;
+                    letter-spacing: 2px;
+                    font-weight: 600;
+                  }
                 }
               }
             }
@@ -605,7 +626,7 @@
               .thumbnail-image{
                 display: flex;
                 width: 25%;
-                margin: 0 10px 0 0;
+                margin: 0 10px 5px 5px;
                 img {
                   object-fit: cover;
                   height: 87px;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -9,11 +9,15 @@
           .itemBox__body
             %ul.up-image
               %li.slide-image
-                = image_tag (@product.images[0].src.url)
+                = image_tag (@product.images[0].src.url), class: "image-main-photo"
+                -if @product.buyer_id.present?
+                  .sold-band
+                    .sold-band-inner
+                      SOLD
             %ul.down-image
-              - @product.images[1..-1].each do |image|
-                %li.thimbnail-image
-                  = image_tag image.src.url
+              - @product.images.each do |image|
+                %li.thumbnail-image
+                  = image_tag image.src.url, class: "image-sub-photo"
           .itemBox__price
             %span
               = @product.price


### PR DESCRIPTION
#what 
商品詳細ページに売り切れた時の表示を作成
商品詳細ページでサムネイル画像をクリックした時、メインと画像が入れ替わる機能を実装

#why
ユーザーが使いやすくなるため