### PR TITLE
マイページメニューのサイドバー横幅微調整

### DIFF
--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -30,7 +30,7 @@
       display: flex;
       .l-side {
         float: left;
-        width: 280px;
+        width: 350px;
         margin: 0 40px 0 0;
         background-color: white;
         .mypage-nav-list {
@@ -54,7 +54,7 @@
       }
       .l-content {
         font-size: 25px;
-        width: 100vw;
+        width: calc(100vw - 350px);
         h1 {
           text-align: center;
         }
@@ -67,7 +67,6 @@
             text-decoration: none;
             font-size: 20px;
             margin-right: 20px;
-            background-color: red;
             margin-top: 20px;
             .bought-item {
               background-color: #f8f8f8;


### PR DESCRIPTION
## what
マイページメニュー画面のビューの崩れを修正

## why
画面を大きくした時と縮小した時いビューの崩れが起こっていたため
